### PR TITLE
npm ci consolidation for PI projects

### DIFF
--- a/generators/package/index.ts
+++ b/generators/package/index.ts
@@ -198,29 +198,6 @@ module.exports = class extends HtmlGenerator {
   }
 
   /**
-   * Utility method to ask the user whether he desires to publish the current created
-   * package to the provided npm registry endpoint
-   */
-  promptForPublish() {
-    return this.prompt(
-      {
-        type: "input",
-        name: "confirmPublish",
-        message: "Do you wish to publish this package to your npm registry endpoint? (y/n)",
-        validate: (input: string, answers: Answers): boolean => {
-          return typeof input === "string" && !!input;
-        },
-        store: false
-      }).then((confirmAnswers) => {
-        if (confirmAnswers.confirmSkip === "y" || confirmAnswers.confirmSkip === "yes" || confirmAnswers.confirmSkip === "Y" || confirmAnswers.confirmSkip === "YES") {
-          return this._publishPackageToNpmRegistry();
-        } else {
-          return null;
-        }
-      });
-  }
-
-  /**
    * Gets the description for each package in the packages array and returns an array with them
    */
   _getAppPackageDescriptions(webAppFolder: string, packages: { name: string }[]): { name?: string, type?: string, line?: string }[] {
@@ -246,28 +223,5 @@ module.exports = class extends HtmlGenerator {
     })
 
     return packagesWithDescription;
-  }
-
-  /**
-   * Publish current package to the provided npm registry endpoint and channel.
-   */
-  private _publishPackageToNpmRegistry() {
-    let filePath = `${this.destinationPath(".dev-tasks.json")}`,
-      fileContent = this.fs.readJSON(this.destinationPath(filePath));
-    let registry, channel;
-    if (fileContent.registry != null) {
-      registry = fileContent.registry;
-    }
-    if (fileContent.channel != null) {
-      channel = fileContent.channel;
-    }
-    try {
-      const result = this.spawnCommandSync("npm", ["publish", `--registry=${registry}`, `--tag=${channel}`], { stdio: 'pipe' });
-      if (result != null && result.stdout != null) {
-        console.log("Package was successfully published.");
-      }
-    } catch (e) {
-      console.log("An error occured trying to publish the package.");
-    }
   }
 }

--- a/generators/package/index.ts
+++ b/generators/package/index.ts
@@ -1,6 +1,7 @@
 import { HtmlGenerator } from "../html";
 import * as fs from "fs";
 import * as path from "path";
+import { Answers } from "yeoman-generator";
 
 module.exports = class extends HtmlGenerator {
 
@@ -9,9 +10,9 @@ module.exports = class extends HtmlGenerator {
   }
 
   dependencies: string[];
-  
+
   constructor(args, opts) {
-    super(args, opts);    
+    super(args, opts);
 
     this.argument('packageName', { type: String, required: true });
     this.options.packageName = this.camelCaseValue(this.options.packageName);
@@ -23,21 +24,21 @@ module.exports = class extends HtmlGenerator {
     // If this command was not executed from the root, exit    
     if (this.config.get("isRoot") !== true) {
       this.env.error(new Error("Please execute this command outside a package. Hint: use the root of the repository."));
-    } 
+    }
   }
 
   /**
   * Will prompt the user with all the dependencies that this new package may have.  
   */
   prompting() {
-    (<any>Set.prototype).union = function(setB) {
+    (<any>Set.prototype).union = function (setB) {
       var union = new Set(this);
       for (var elem of setB) {
-          union.add(elem);
+        union.add(elem);
       }
       return union;
     };
-    (<any>Set.prototype).difference = function(setB) {
+    (<any>Set.prototype).difference = function (setB) {
       var difference = new Set(this);
       for (var elem of setB) {
         difference.delete(elem);
@@ -59,26 +60,26 @@ module.exports = class extends HtmlGenerator {
     if (fs.existsSync(this.destinationPath("src", "packages"))) {
       repositoryPackages = new Set(fs.readdirSync(this.destinationPath("src", "packages")));
     }
-    
+
     if (fs.existsSync(this.destinationPath(webAppFolder, "node_modules"))) {
       const excludeFilter = (folder) => { return folder.startsWith("cmf") && ["cmf.taura", "cmf.core", "cmf.core.multicast.client", "cmf.mes", "cmf.polyfill", "cmf.angular", "cmf.instascan", "cmf.core.examples", "cmf.mes.examples"].indexOf(folder) < 0 && !folder.startsWith("cmf.style") };
       webAppPackages = new Set(fs.readdirSync(this.destinationPath(webAppFolder, "node_modules")).filter(excludeFilter));
     }
-    
+
     allPackages = (<any>repositoryPackages).union(webAppPackages);
-    const packageNames: {name: string, checked: boolean}[] = Array.from(allPackages).filter((pkg) => !(<string>pkg).startsWith(".")).sort().map((pkg) => {return {name: pkg, checked: pkg === "cmf.lbos" }})
+    const packageNames: { name: string, checked: boolean }[] = Array.from(allPackages).filter((pkg) => !(<string>pkg).startsWith(".")).sort().map((pkg) => { return { name: pkg, checked: pkg === "cmf.lbos" } })
     const choices = this._getAppPackageDescriptions(webAppFolder, packageNames);
-    
+
     return this.prompt([{
-      type    : 'checkbox',
-      name    : 'dependencies',      
-      message : `Select dependencies`,
+      type: 'checkbox',
+      name: 'dependencies',
+      message: `Select dependencies`,
       choices: choices,
       pageSize: 18, // We can set up the pageSize attribute but there’s a PR opened ATM to make the height match the terminal height. Soon this won’t be necessary
-      default : undefined,
-      when    : () => Array.from(allPackages).length > 0
+      default: undefined,
+      when: () => Array.from(allPackages).length > 0
     }]).then((answers) => {
-      if (answers.dependencies instanceof Array && answers.dependencies.length > 0) {        
+      if (answers.dependencies instanceof Array && answers.dependencies.length > 0) {
         this.dependencies = answers.dependencies.filter((entry) => entry !== "");
       }
     });
@@ -92,13 +93,13 @@ module.exports = class extends HtmlGenerator {
   * - Will update the config.json of the web app, so it loads the new package once it starts
   * - Will update the root's .dev.tasks.json so when a "gulp install" or "gulp build" is issued at root level, it will also account for the new package.
   */
-  copyTemplates() {        
-    const packageConfig = {name: this.options.packageName};
+  copyTemplates() {
+    const packageConfig = { name: this.options.packageName };
     const templatesToParse = [
       'package.json',
       'gulpfile.js',
-      '.yo-rc.json', 
-      {templateBefore: '__.npmignore', templateAfter: '.npmignore'}
+      '.yo-rc.json',
+      { templateBefore: '__.npmignore', templateAfter: '.npmignore' }
     ];
     const packagesFolder = 'src/packages/';
     const repository = this.destinationRoot().split("\\").pop();
@@ -110,39 +111,39 @@ module.exports = class extends HtmlGenerator {
     ];
 
     if (this.ctx.__config.registry) {
-      templatesToParse.push({ templateBefore: '__.npmrc', templateAfter: '.npmrc'});
+      templatesToParse.push({ templateBefore: '__.npmrc', templateAfter: '.npmrc' });
     }
 
     this.fs.copy(<any>copyArray, this.destinationPath(packagesFolder, this.options.packageName));
     templatesToParse.forEach((template) => {
-        let templateBefore = typeof template === "string" ? template : template.templateBefore,
+      let templateBefore = typeof template === "string" ? template : template.templateBefore,
         templateAfter = typeof template === "string" ? template : template.templateAfter;
-        this.fs.copyTpl(this.templatePath(templateBefore), this.destinationPath(`${packagesFolder}${this.options.packageName}/${templateAfter}`), {package: packageConfig, registry: this.ctx.__config.registry})
-      });
+      this.fs.copyTpl(this.templatePath(templateBefore), this.destinationPath(`${packagesFolder}${this.options.packageName}/${templateAfter}`), { package: packageConfig, registry: this.ctx.__config.registry })
+    });
 
     // Let's update the destination package.json with the lbos and any dependencies that may have been defined
     const packageJSONPath = `${packagesFolder}${this.options.packageName}/package.json`;
     const packageJSONObject = this.fs.readJSON(this.destinationPath(packageJSONPath));
-    const appLibsFolder = `file:../../../apps/${this.ctx.packagePrefix}.web/node_modules/`;    
-        
-    if (this.dependencies instanceof Array && this.dependencies.length > 0) {          
+    const appLibsFolder = `file:../../../apps/${this.ctx.packagePrefix}.web/node_modules/`;
+
+    if (this.dependencies instanceof Array && this.dependencies.length > 0) {
       this.dependencies.forEach((dependency) => {
         let link: string;
         if (dependency.startsWith("cmf.core") && repository === "MESHTML") {
           link = `file:../../../../CoreHTML/${packagesFolder}${dependency}`;
-        } else if ((dependency.startsWith(this.ctx.packagePrefix))) {    
-          link = `file:../${dependency}`;          
+        } else if ((dependency.startsWith(this.ctx.packagePrefix))) {
+          link = `file:../${dependency}`;
         } else {
-          link = `${appLibsFolder}${dependency}`;  
+          link = `${appLibsFolder}${dependency}`;
         }
         packageJSONObject.cmfLinkDependencies[dependency] = link;
         packageJSONObject.optionalDependencies[dependency] = this.ctx.__config.channel;
       });
-    } 
+    }
 
     let extendingMES: boolean = false;
     // We need one fallback at the end. If we are customizing, we can end up using ony packages from CORE and we need to customize on top of MES
-    if (Object.keys(packageJSONObject.optionalDependencies).some(function(dependency) {return dependency.startsWith("cmf.mes")})) {
+    if (Object.keys(packageJSONObject.optionalDependencies).some(function (dependency) { return dependency.startsWith("cmf.mes") })) {
       packageJSONObject.cmfLinkDependencies["cmf.mes"] = `${appLibsFolder}cmf.mes`;
       packageJSONObject.optionalDependencies["cmf.mes"] = this.ctx.__config.channel;
       // Also depend on cmf.core as we are going to need it for typings
@@ -155,17 +156,17 @@ module.exports = class extends HtmlGenerator {
       packageJSONObject.optionalDependencies["cmf.core"] = this.ctx.__config.channel;
     }
 
-    this.fs.writeJSON(packageJSONPath, packageJSONObject);     
+    this.fs.writeJSON(packageJSONPath, packageJSONObject);
 
     // Now that we know if we extended cmf.mes or cmf.core, we must copy the metadata file, parsing the template using this information
-    this.fs.copyTpl(this.templatePath('src/metadata.ts'), this.destinationPath(`${packagesFolder}${this.options.packageName}/src/${packageConfig.name}.metadata.ts`), {extendingMES: extendingMES })
+    this.fs.copyTpl(this.templatePath('src/metadata.ts'), this.destinationPath(`${packagesFolder}${this.options.packageName}/src/${packageConfig.name}.metadata.ts`), { extendingMES: extendingMES })
 
     /** We also want to update the package.json of the webApp. if the package prefix starts with "cmf", we are dealing with COREHTML or MESHTML
     * In these cases when linking to the web app, the prefix is not enough, because the webApp is "cmf.core.web" and "cmf.mes.web".
     * if the package being created starts with "cmf" and then "core", we are in COREHTML. If it's cmf.mes, then it's MESHTML. If it does not
     * start with "cmf", then is a customization scenario. In these cases there's no need to have another name after the prefix. 
-    */   
-    this.updateWebAppPackageJSON(`file:../../${packagesFolder}${this.options.packageName}`);   
+    */
+    this.updateWebAppPackageJSON(`file:../../${packagesFolder}${this.options.packageName}`);
 
     // By updating the webApp's package.json we also need to update the config.json file with the new package
     this.webAppFoldersPath.forEach(webAppFolderPath => {
@@ -180,26 +181,49 @@ module.exports = class extends HtmlGenerator {
 
     // We also need to update the root's .dev-tasks.js so this new package is included in the global install and build tasks
     let filePath = `${this.destinationPath(".dev-tasks.json")}`,
-    fileContent = this.fs.readJSON(this.destinationPath(filePath));
+      fileContent = this.fs.readJSON(this.destinationPath(filePath));
     if (fileContent.packages.indexOf(this.options.packageName) < 0) {
-      fileContent.packages.push(this.options.packageName);  
+      fileContent.packages.push(this.options.packageName);
     }
-    this.fs.writeJSON(filePath, fileContent);      
+    this.fs.writeJSON(filePath, fileContent);
   }
 
   /** 
   * Will install both the new package as well as the web app
   */
   install() {
-    super.install(`src/packages/${this.options.packageName}`);  
+    super.install(`src/packages/${this.options.packageName}`);
     this.destinationRoot(`src/packages/${this.options.packageName}`);
     this.spawnCommandSync("gulp", ["build"]);
   }
 
   /**
+   * Utility method to ask the user whether he desires to publish the current created
+   * package to the provided npm registry endpoint
+   */
+  promptForPublish() {
+    return this.prompt(
+      {
+        type: "input",
+        name: "confirmPublish",
+        message: "Do you wish to publish this package to your npm registry endpoint? (y/n)",
+        validate: (input: string, answers: Answers): boolean => {
+          return typeof input === "string" && !!input;
+        },
+        store: false
+      }).then((confirmAnswers) => {
+        if (confirmAnswers.confirmSkip === "y" || confirmAnswers.confirmSkip === "yes" || confirmAnswers.confirmSkip === "Y" || confirmAnswers.confirmSkip === "YES") {
+          return this._publishPackageToNpmRegistry();
+        } else {
+          return null;
+        }
+      });
+  }
+
+  /**
    * Gets the description for each package in the packages array and returns an array with them
    */
-  _getAppPackageDescriptions(webAppFolder: string, packages: {name: string}[]): {name?: string, type?: string, line?: string}[] {
+  _getAppPackageDescriptions(webAppFolder: string, packages: { name: string }[]): { name?: string, type?: string, line?: string }[] {
     if (packages == null || packages.length === 0) {
       return [];
     }
@@ -214,13 +238,36 @@ module.exports = class extends HtmlGenerator {
       if (fs.existsSync(packageJsonPath)) {
         const packageJSONObject = this.fs.readJSON(packageJsonPath);
         if (packageJSONObject != null && packageJSONObject["description"] != null && packageJSONObject["description"] != "") {
-          packageInfo.push({type: "separator", line: `    ${packageJSONObject["description"]}`});
-          packageInfo.push({type: "separator", line: "        "});
+          packageInfo.push({ type: "separator", line: `    ${packageJSONObject["description"]}` });
+          packageInfo.push({ type: "separator", line: "        " });
         }
       }
       packagesWithDescription.push(...packageInfo);
     })
 
     return packagesWithDescription;
+  }
+
+  /**
+   * Publish current package to the provided npm registry endpoint and channel.
+   */
+  private _publishPackageToNpmRegistry() {
+    let filePath = `${this.destinationPath(".dev-tasks.json")}`,
+      fileContent = this.fs.readJSON(this.destinationPath(filePath));
+    let registry, channel;
+    if (fileContent.registry != null) {
+      registry = fileContent.registry;
+    }
+    if (fileContent.channel != null) {
+      channel = fileContent.channel;
+    }
+    try {
+      const result = this.spawnCommandSync("npm", ["publish", `--registry=${registry}`, `--tag=${channel}`], { stdio: 'pipe' });
+      if (result != null && result.stdout != null) {
+        console.log("Package was successfully published.");
+      }
+    } catch (e) {
+      console.log("An error occured trying to publish the package.");
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/generator-html",
-  "version": "7.1.0-2",
+  "version": "7.1.0-3",
   "description": "CMF HTML GUI Scaffolding",
   "files": [
     "generators/*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/generator-html",
-  "version": "7.1.0-3",
+  "version": "7.1.0-4",
   "description": "CMF HTML GUI Scaffolding",
   "files": [
     "generators/*.js",


### PR DESCRIPTION
 Added prompting to check if the user wants to publish the created package to his npm registry.
This change is to complement the changes to dev-tasks, which now uses npm ci when executing the gulp install task, when a package has a package-lock.json. npm ci requires that the packages listed in the package-lock.json need to be publicated or the npm ci errors and does not install any dependencies, where as in npm install does not.
This will require that each PI project have a private npm registry to publish these newly created packages. This change was already discussed with @m-s- .