### PR TITLE
Node 12 Force graceful-fs version

### DIFF
--- a/generators/application/templates/npm.postinstall.js
+++ b/generators/application/templates/npm.postinstall.js
@@ -1,0 +1,24 @@
+var Path = require("path");
+var fs = require('fs');
+var fileContent = `{ "dependencies": { "graceful-fs": { "version": "4.2.2" } } }`;
+var filePath = Path.join(__dirname, "package-lock");
+
+// Clean package lock backup
+fs.exists(`${filePath}-original.json`, (exists) => {
+	if (exists) {
+		fs.readFile(`${filePath}.json`, { encoding: 'utf-8' }, (err, data) => {
+			if (!err) {
+				if (data.length === fileContent.length) {
+					// It means that the package-lock wasn't changed (npm ci)
+					fs.unlinkSync(`${filePath}.json`);
+					fs.renameSync(`${filePath}-original.json`, `${filePath}.json`);
+				}
+				else {
+					fs.unlinkSync(`${filePath}-original.json`);
+				}
+			} else {
+				console.log(err);
+			}
+		});
+	}
+});

--- a/generators/application/templates/npm.preinstall.js
+++ b/generators/application/templates/npm.preinstall.js
@@ -1,0 +1,16 @@
+var Path = require("path");
+var fs = require('fs');
+var fileContent = `{ "dependencies": { "graceful-fs": { "version": "4.2.2" } } }`;
+var filePath = Path.join(__dirname, "package-lock");
+
+// Check if package lock exists and then, create a backup
+fs.exists(`${filePath}.json`, (exists) => {
+	if (exists) {
+		fs.copyFileSync(`${filePath}.json`, `${filePath}-original.json`, (err) => {
+			if (err) return console.log(err);
+		});
+	} 
+	fs.writeFileSync(`${filePath}.json`, fileContent, 'utf8', (err) => {
+		if (err) return console.log(err);
+	});
+});

--- a/generators/application/templates/package.json
+++ b/generators/application/templates/package.json
@@ -2,6 +2,10 @@
   "name": "<%= package %>",
   "version": "0.0.1",
   "description": "<%= package %> package",
+  "scripts": {
+    "preinstall": "node npm.preinstall.js",
+    "postinstall": "node npm.postinstall.js"
+  },
   "dependencies": {
     <% if (basePackage && channel) { %>
     "<%= basePackage %>": "<%= channel %>"

--- a/generators/framework/templates/npm.postinstall.js
+++ b/generators/framework/templates/npm.postinstall.js
@@ -1,0 +1,24 @@
+var Path = require("path");
+var fs = require('fs');
+var fileContent = `{ "dependencies": { "graceful-fs": { "version": "4.2.2" } } }`;
+var filePath = Path.join(__dirname, "package-lock");
+
+// Clean package lock backup
+fs.exists(`${filePath}-original.json`, (exists) => {
+	if (exists) {
+		fs.readFile(`${filePath}.json`, { encoding: 'utf-8' }, (err, data) => {
+			if (!err) {
+				if (data.length === fileContent.length) {
+					// It means that the package-lock wasn't changed (npm ci)
+					fs.unlinkSync(`${filePath}.json`);
+					fs.renameSync(`${filePath}-original.json`, `${filePath}.json`);
+				}
+				else {
+					fs.unlinkSync(`${filePath}-original.json`);
+				}
+			} else {
+				console.log(err);
+			}
+		});
+	}
+});

--- a/generators/framework/templates/npm.preinstall.js
+++ b/generators/framework/templates/npm.preinstall.js
@@ -1,0 +1,16 @@
+var Path = require("path");
+var fs = require('fs');
+var fileContent = `{ "dependencies": { "graceful-fs": { "version": "4.2.2" } } }`;
+var filePath = Path.join(__dirname, "package-lock");
+
+// Check if package lock exists and then, create a backup
+fs.exists(`${filePath}.json`, (exists) => {
+	if (exists) {
+		fs.copyFileSync(`${filePath}.json`, `${filePath}-original.json`, (err) => {
+			if (err) return console.log(err);
+		});
+	} 
+	fs.writeFileSync(`${filePath}.json`, fileContent, 'utf8', (err) => {
+		if (err) return console.log(err);
+	});
+});

--- a/generators/framework/templates/package.json
+++ b/generators/framework/templates/package.json
@@ -2,6 +2,10 @@
   "name": "<%= package.name %>",
   "version": "0.0.1",
   "description": "<%= package.name %> package",
+  "scripts": {
+    "preinstall": "node npm.preinstall.js",
+    "postinstall": "node npm.postinstall.js"
+  },
   "main": "<%= package.name %>.js",
   "types": "index.d.ts",
   "dependencies": {},

--- a/generators/framework/templates/tsconfig.json
+++ b/generators/framework/templates/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "system",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/generators/package/templates/npm.postinstall.js
+++ b/generators/package/templates/npm.postinstall.js
@@ -1,0 +1,24 @@
+var Path = require("path");
+var fs = require('fs');
+var fileContent = `{ "dependencies": { "graceful-fs": { "version": "4.2.2" } } }`;
+var filePath = Path.join(__dirname, "package-lock");
+
+// Clean package lock backup
+fs.exists(`${filePath}-original.json`, (exists) => {
+	if (exists) {
+		fs.readFile(`${filePath}.json`, { encoding: 'utf-8' }, (err, data) => {
+			if (!err) {
+				if (data.length === fileContent.length) {
+					// It means that the package-lock wasn't changed (npm ci)
+					fs.unlinkSync(`${filePath}.json`);
+					fs.renameSync(`${filePath}-original.json`, `${filePath}.json`);
+				}
+				else {
+					fs.unlinkSync(`${filePath}-original.json`);
+				}
+			} else {
+				console.log(err);
+			}
+		});
+	}
+});

--- a/generators/package/templates/npm.preinstall.js
+++ b/generators/package/templates/npm.preinstall.js
@@ -1,0 +1,16 @@
+var Path = require("path");
+var fs = require('fs');
+var fileContent = `{ "dependencies": { "graceful-fs": { "version": "4.2.2" } } }`;
+var filePath = Path.join(__dirname, "package-lock");
+
+// Check if package lock exists and then, create a backup
+fs.exists(`${filePath}.json`, (exists) => {
+	if (exists) {
+		fs.copyFileSync(`${filePath}.json`, `${filePath}-original.json`, (err) => {
+			if (err) return console.log(err);
+		});
+	} 
+	fs.writeFileSync(`${filePath}.json`, fileContent, 'utf8', (err) => {
+		if (err) return console.log(err);
+	});
+});

--- a/generators/package/templates/package.json
+++ b/generators/package/templates/package.json
@@ -1,7 +1,11 @@
 {
   "name": "<%= package.name %>",
   "version": "0.0.1",
-  "description": "<%= package.name %> package",  
+  "description": "<%= package.name %> package",
+  "scripts": {
+    "preinstall": "node npm.preinstall.js",
+    "postinstall": "node npm.postinstall.js"
+  },  
   "main": "<%= package.name %>.js",
   "types": "index.d.ts",  
   "dependencies": {},

--- a/generators/package/templates/tsconfig.json
+++ b/generators/package/templates/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "system",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/generator-html",
-  "version": "7.1.1",
+  "version": "8.0.0-0",
   "description": "CMF HTML GUI Scaffolding",
   "files": [
     "generators/*.js",


### PR DESCRIPTION
To minimize the impact of Node 12 support, it was developed a mechanism to force graceful-fs version in npm installations.