### PR TITLE
Add lodash dependency to ensure correct version is dedup

### DIFF
--- a/generators/application/index.ts
+++ b/generators/application/index.ts
@@ -85,6 +85,8 @@ export = class extends HtmlGenerator {
     if (this.fs.exists(configPath)) {
       // Try to assign dynamic bundles location (optional task)
       try {
+        // delete file to recreate it from the base package
+        fs.unlinkSync(this.destinationPath("config.json"));
         // Copy config setup file
         fs.copyFileSync(configPath, this.destinationPath("config.json"));
         // Regular expression to find the bundle path within non standard config JSON

--- a/generators/application/index.ts
+++ b/generators/application/index.ts
@@ -70,10 +70,15 @@ export = class extends HtmlGenerator {
     });
     this.fs.copy(this.templatePath("web.config"), this.destinationPath("web.config"));
     this.fs.copy(this.templatePath("manifest.json"), this.destinationPath("manifest.json"));
+    this.fs.copy(this.templatePath("config.json"), this.destinationPath("config.json"));
     this.fs.copyTpl(this.templatePath("index.html"), this.destinationPath("index.html"), {isExtendingMes: this.basePackage === WebAppName.MES});
   }
 
   install() {
+    // Install the web
+    this.spawnCommandSync('gulp', ['purge']);
+    this.spawnCommandSync('gulp', ['install']);
+
     // Try to populate settings
     const configPath = this.destinationPath("node_modules", this.basePackage, "config.setup.json");
     // Add here other files that may have settings
@@ -136,16 +141,8 @@ export = class extends HtmlGenerator {
       catch (error) {
         this.fs.copy(this.templatePath("config.json"), this.destinationPath("config.json"));
       }
-    } else {
-      this.fs.copy(this.templatePath("config.json"), this.destinationPath("config.json"));
     }
 
     this.log(`Please configure the file ${this.destinationPath("config.json")}`);
   }
-
-  end() {
-    // Install the web after all files are generated
-    this.spawnCommandSync('gulp', ['purge']);
-    this.spawnCommandSync('gulp', ['install']);
- }
 }

--- a/generators/application/templates/package.json
+++ b/generators/application/templates/package.json
@@ -4,8 +4,8 @@
   "description": "<%= package %> package",
   "dependencies": {
     <% if (basePackage && channel) { %>
-    "<%= basePackage %>": "<%= channel %>"
-    <% } %>,
+    "<%= basePackage %>": "<%= channel %>",
+    <% } %>
 	"lodash": "3.10.1"
   },
   "optionalDependencies": {},

--- a/generators/application/templates/package.json
+++ b/generators/application/templates/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     <% if (basePackage && channel) { %>
     "<%= basePackage %>": "<%= channel %>"
-    <% } %>
+    <% } %>,
+	"lodash": "3.10.1"
   },
   "optionalDependencies": {},
   "cmfLinkDependencies" : {}


### PR DESCRIPTION
Due to external dependencies within the HTML starter project, lodash was being set to version 4.17 instead of 3.10.1.
This appears to be npm dedup issue, this is a workaround until dependencies are not upgrade to version 4.x
